### PR TITLE
Added routes for Expense and Occurrence models

### DIFF
--- a/wallet/app/models/expense.rb
+++ b/wallet/app/models/expense.rb
@@ -1,5 +1,5 @@
 class Expense < ApplicationRecord
     belongs_to :user
     has_many :expense_occurences
-    enum recur: {none: 0, daily: 1, weekly: 7, fortnightly: 14, monthly: 28, quarterly: 90, biannual: 182, annual: 365} 
+    enum recur: {once: 0, daily: 1, weekly: 7, fortnightly: 14, monthly: 28, quarterly: 90, biannual: 182, annual: 365} 
 end

--- a/wallet/config/routes.rb
+++ b/wallet/config/routes.rb
@@ -3,4 +3,6 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'pages#home'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  
+  resources :expenses, :expense_occurrence
 end

--- a/wallet/config/routes.rb
+++ b/wallet/config/routes.rb
@@ -4,5 +4,7 @@ Rails.application.routes.draw do
   root to: 'pages#home'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   
-  resources :expenses, :expense_occurrence
+  resources :expenses do
+     resources :expense_occurrence
+  end
 end


### PR DESCRIPTION
Added routing for Expense and Expense_Occurrence models.

Used "resources :expense, :expense_occurrence" to provide index routes for both models. Nesting resources was not going to make this happen.

When selecting multiple occurrences for an expense, it will require running a method to determine the grouping of the occurences for that expense